### PR TITLE
Navngir Terraform Lint jobb

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ env:
   GHA_TERRAFORM_LINT_VERSION: ${{ inputs.version }}
 jobs:
   lint:
+    name: Terraform Lint
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:


### PR DESCRIPTION
Navngir selve jobben i Entur/Terraform/Lint workflowen sånn at navnet vises i Workflow grafen der denne er brukt.

Se entur/gha-docker#121 for liknende endring der, med screenshots.