### PR TITLE
fix: set minimum failure severity for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
     uses: ./.github/workflows/lint.yml
     with:
       directory: fixture/terraform_with_changes
+  test-lint-with-warning-ok:
+    name: Test Lint Passes with Warning
+    uses: ./.github/workflows/lint.yml
+    with:
+      directory: fixture/terraform_with_warning
 
   verify-version:
     needs: test-lint-ok

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
           printf "%bRunning TFLint: %b\n" "${YELLOW}" "${NEUTRAL}"
           printf "#--------------------------------------------------------------------------------\n"
           tflint --init
-          if ! tflint --chdir=${GHA_TERRAFORM_DIRECTORY} --recursive; then
+          if ! tflint --chdir=${GHA_TERRAFORM_DIRECTORY} --recursive --minimum-failure-severity=error; then
             printf "#--------------------------------------------------------------------------------\n"
             printf "%bERROR%b: TFLint found issues in the Terraform configuration\n" "${RED}" "${NEUTRAL}"
             printf "Please check the error messages above and fix the issue\n\n"

--- a/fixture/terraform_with_warning/backend.tf
+++ b/fixture/terraform_with_warning/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "1.8.3"
+  backend "gcs" {
+    bucket = "ent-gcs-tfa-ghaci"
+    prefix = "ci_test_no_changes/gha-terraform.tfstate"
+  }
+}

--- a/fixture/terraform_with_warning/env/dev.tfvars
+++ b/fixture/terraform_with_warning/env/dev.tfvars
@@ -1,0 +1,1 @@
+environment = "dev"

--- a/fixture/terraform_with_warning/main.tf
+++ b/fixture/terraform_with_warning/main.tf
@@ -1,0 +1,6 @@
+# Terraform Entur init configuration
+module "init" {
+  source      = "github.com/entur/terraform-google-init//modules/init?ref=v1.0.0"
+  app_id      = "ghaci"
+  environment = var.environment
+}

--- a/fixture/terraform_with_warning/variables.tf
+++ b/fixture/terraform_with_warning/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  description = "Environment abbreviation, f.e. dev"
+}

--- a/fixture/terraform_with_warning/versions.tf
+++ b/fixture/terraform_with_warning/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "1.8.3"
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.4"
+    }
+  }
+}


### PR DESCRIPTION
An update to tflint changed its default behavior: without the `--minimum-failure-severity` flag set to `error`, tflint exits with a non-zero exit code and the linting Github action fails on warnings. Setting the failure severity to `error` brings back previous behavior.