### PR TITLE
fix: don't zip tfplan.txt and tfapply.txt

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -264,7 +264,7 @@ jobs:
             files.sort(filesort)
             const codeblockstart = '```tf\n'
             const codeblockend = '\n```\n'
-            const downloadlink = `\n[Download Apply Log](${process.env.GHA_ARTIFACT_DOWNLOAD_LINK})\n`;
+            const downloadlink = `\n[View full apply log](${process.env.GHA_ARTIFACT_DOWNLOAD_LINK})\n`;
             let apply = '';
             let n = 0;
             let body = '';

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -241,7 +241,7 @@ jobs:
             files.sort(filesort)
             const codeblockstart = '```tf\n'
             const codeblockend = '\n```\n'
-            const downloadlink = `\n[Download Plan](${process.env.GHA_ARTIFACT_DOWNLOAD_LINK})\n`;
+            const downloadlink = `\n[View full plan](${process.env.GHA_ARTIFACT_DOWNLOAD_LINK})\n`;
             let plan = '';
             let n = 0;
             let body = '';


### PR DESCRIPTION
* New feature: https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/
* Changes "Download Plan / Apply" button to "View full plan/ apply log"
* Required major bump of upload-artifact to V7.