### PR TITLE
feat: add extra_tf_vars input to plan and apply workflows

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -37,6 +37,10 @@ on:
         description: "Job timeout in minutes"
         type: number
         default: 60
+      extra_tf_vars:
+        description: "Extra Terraform variables to pass to plan, one per line in KEY=value format"
+        type: string
+        default: ""
     outputs:
       version:
         description: "Terraform version (may be empty if terraform-apply job is skipped when has_changes != 'true')"
@@ -59,6 +63,7 @@ jobs:
       GHA_TERRAFORM_VERSION: ${{ inputs.version }}
       GHA_TERRAFORM_GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
       GHA_TERRAFORM_GCP_CLUSTER_NAME: ${{ inputs.gcp_cluster_name }}
+      GHA_TERRAFORM_EXTRA_TF_VARS: ${{ inputs.extra_tf_vars }}
       GHA_TERRAFORM_PLAN_STATUS: 0
       GHA_TERRAFORM_PLAN_SUMMARY: ""
       GHA_TERRAFORM_APPLY_STATUS: 0
@@ -125,9 +130,15 @@ jobs:
         working-directory: ${{ env.GHA_TERRAFORM_DIRECTORY }}
         shell: bash
         run: |
+          # Build -var flags from extra_tf_vars input (one KEY=value per line)
+          EXTRA_VAR_ARGS=()
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            EXTRA_VAR_ARGS+=("-var" "$line")
+          done <<< "${GHA_TERRAFORM_EXTRA_TF_VARS}"
           set +e
           # Run terraform plan and save the plan to a file, but also save any errors to a variable
-          { err=$(terraform plan -var-file=env/${GHA_TERRAFORM_ENVIRONMENT}.tfvars -detailed-exitcode -no-color -out tfplan 2>&1 >&3 3>&-); } 3>&1
+          { err=$(terraform plan -var-file=env/${GHA_TERRAFORM_ENVIRONMENT}.tfvars "${EXTRA_VAR_ARGS[@]}" -detailed-exitcode -no-color -out tfplan 2>&1 >&3 3>&-); } 3>&1
           echo "GHA_TERRAFORM_PLAN_STATUS=$?" >> $GITHUB_ENV
           set -e
           # Save the multiline error to the Summary, if empty/ok, it will be overwritten later

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -23,6 +23,10 @@ on:
         description: "Job timeout in minutes"
         type: number
         default: 10
+      extra_tf_vars:
+        description: "Extra Terraform variables to pass to plan, one per line in KEY=value format"
+        type: string
+        default: ""
       # skip these - only used by fellestjenester.
       cloud_provider:
         description: "Which cloud service provider to use - Google Cloud: 'gcp' is currently the only supported option"
@@ -58,6 +62,7 @@ jobs:
       GHA_TERRAFORM_VERSION: ${{ inputs.version }}
       GHA_TERRAFORM_GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
       GHA_TERRAFORM_GCP_CLUSTER_NAME: ${{ inputs.gcp_cluster_name }}
+      GHA_TERRAFORM_EXTRA_TF_VARS: ${{ inputs.extra_tf_vars }}
       GHA_TERRAFORM_PLAN_STATUS: 0
       GHA_TERRAFORM_PLAN_SUMMARY: ""
       WORKLOAD_IDENTITY_PROVIDER: ${{ vars.CI_WORKLOAD_IDENTITY_PROVIDER }}
@@ -126,9 +131,15 @@ jobs:
         working-directory: ${{ env.GHA_TERRAFORM_DIRECTORY }}
         shell: bash
         run: |
+          # Build -var flags from extra_tf_vars input (one KEY=value per line)
+          EXTRA_VAR_ARGS=()
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            EXTRA_VAR_ARGS+=("-var" "$line")
+          done <<< "${GHA_TERRAFORM_EXTRA_TF_VARS}"
           set +e
           # Run terraform plan and save the plan to a file, but also save any errors to a variable
-          { err=$(terraform plan -var-file=env/${GHA_TERRAFORM_ENVIRONMENT}.tfvars -detailed-exitcode -no-color -out tfplan -lock=false 2>&1 >&3 3>&-); } 3>&1
+          { err=$(terraform plan -var-file=env/${GHA_TERRAFORM_ENVIRONMENT}.tfvars "${EXTRA_VAR_ARGS[@]}" -detailed-exitcode -no-color -out tfplan -lock=false 2>&1 >&3 3>&-); } 3>&1
           echo "GHA_TERRAFORM_PLAN_STATUS=$?" >> $GITHUB_ENV
           set -e
           # Save the multiline error to the Summary, if empty/ok, it will be overwritten later


### PR DESCRIPTION
## Summary

Adds an `extra_tf_vars` input to both `plan.yml` and `apply.yml` so callers can pass additional Terraform variables to the underlying `terraform plan` command.

## Motivation

Some Terraform variables are only known at runtime — typically a Docker image tag produced by a preceding job in the same workflow. Today there is no way to feed such a value into the reusable workflow:

- env vars and `secrets: inherit` do not cross the `workflow_call` boundary
- the only existing channel is `-var-file=env/<env>.tfvars`, which cannot reference job outputs

The workaround has been to inline the entire Terraform setup in the caller (auth, init, plan, apply), losing the value of the reusable workflow. This input keeps callers on the reusable workflow.

## Behavior

- Type: `string`, multiline, one `KEY=value` per line
- Default: `""` — existing callers are unaffected
- Empty lines are skipped
- Each line is appended as a `-var "KEY=value"` argument to `terraform plan`

## Usage

```yaml
tf-plan:
  needs: docker-push
  uses: entur/gha-terraform/.github/workflows/plan.yml@v2
  with:
    environment: dev
    extra_tf_vars: |
      docker_image_name=${{ needs.docker-push.outputs.image_and_tag }}
```

## Notes

- `apply.yml` runs its own `terraform plan` before `terraform apply tfplan`, so the input is wired into both workflows.
- The README input tables are auto-generated (`AUTO-DOC-INPUT`), so they are not touched here.